### PR TITLE
dns_ispconfig.sh client_id not numeric at ispconfig v 3.2.7p1

### DIFF
--- a/dnsapi/dns_ispconfig.sh
+++ b/dnsapi/dns_ispconfig.sh
@@ -127,7 +127,7 @@ _ISPC_getZoneInfo() {
   curResult="$(_post "${curData}" "${ISPC_Api}?client_get_id")"
   _debug "Calling _ISPC_ClientGetID: '${curData}' '${ISPC_Api}?client_get_id'"
   _debug "Result of _ISPC_ClientGetID: '$curResult'"
-  client_id=$(echo "${curResult}" | _egrep_o "response.*" | cut -d ':' -f 2 | cut -d '"' -f 2 | tr -d '{}')
+  client_id=$(echo "${curResult}" | _egrep_o "response.*" | cut -d ':' -f 2 | cut -d '"' -f 2 | cut -d '[' -f 1 | tr -d '{}')
   _debug "Client ID: '${client_id}'"
   case "${client_id}" in
   '' | *[!0-9]*)


### PR DESCRIPTION
Getting client_id failed due to incorrect extraction!

At least in version 3.2.7p1 and probably later the plugin is not working any more properly. The result of ``curResult="$(_post "${curData}" "${ISPC_Api}?client_get_id")"`` is something like this 

``Result of _ISPC_ClientGetID: '[Tue Jan 23 11:44:57 CET 2024] Retrying post 
{"code":"ok","message":"","response":3}[Tue Jan 23 11:44:57 CET 2024] _hcode 0'``.

The parsing code does not work properly and leaves a non numeric value such as ```Client ID: '3[Tue Jan 23 11'```.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->